### PR TITLE
Update search indexer configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,6 @@
-FROM jruby:9.1 AS gem-build
+FROM docker.elastic.co/logstash/logstash-oss:6.3.2
 
-RUN apt-get update \
-    && apt-get install -y git \
-    && mkdir -p /usr/local/src && cd /usr/local/src/ \
-    && git clone https://github.com/SvenW/logstash-input-google_pubsub \
-    && cd logstash-input-google_pubsub \
-    && git checkout f4b06da95069cd6caf8ae9ee0b6e23300649e9f6 \
-    && ./ci/build.sh \
-    && gem build logstash-input-google_pubsub.gemspec
-
-
-FROM docker.elastic.co/logstash/logstash-oss:6.2.2
-
-COPY --from=gem-build /usr/local/src/logstash-input-google_pubsub/logstash-input-google_pubsub-1.0.4.gem /tmp
-RUN logstash-plugin install /tmp/logstash-input-google_pubsub-1.0.4.gem
+RUN logstash-plugin install logstash-input-google_pubsub
 USER root
 RUN mkdir -p /usr/share/scaife-viewer && chown logstash:logstash /usr/share/scaife-viewer
 USER logstash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/logstash/logstash-oss:6.2.4
+FROM docker.elastic.co/logstash/logstash-oss:6.3.2
 
 RUN logstash-plugin install logstash-input-google_pubsub
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,10 @@ RUN apt-get update \
     && gem build logstash-input-google_pubsub.gemspec
 
 
-FROM docker.elastic.co/logstash/logstash-oss:6.2.4
+FROM docker.elastic.co/logstash/logstash-oss:6.2.2
 
-COPY --from=gem-build /usr/local/src/logstash-input-google_pubsub/logstash-input-google_pubsub-1.1.0.gem /tmp
-RUN logstash-plugin install /tmp/logstash-input-google_pubsub-1.1.0.gem
+COPY --from=gem-build /usr/local/src/logstash-input-google_pubsub/logstash-input-google_pubsub-1.0.4.gem /tmp
+RUN logstash-plugin install /tmp/logstash-input-google_pubsub-1.0.4.gem
 USER root
 RUN mkdir -p /usr/share/scaife-viewer && chown logstash:logstash /usr/share/scaife-viewer
 USER logstash

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
     && mkdir -p /usr/local/src && cd /usr/local/src/ \
     && git clone https://github.com/SvenW/logstash-input-google_pubsub \
     && cd logstash-input-google_pubsub \
-    && git checkout f4b06da95069cd6caf8ae9ee0b6e23300649e9f6
+    && git checkout f4b06da95069cd6caf8ae9ee0b6e23300649e9f6 \
     && ./ci/build.sh \
     && gem build logstash-input-google_pubsub.gemspec
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,18 @@
-FROM docker.elastic.co/logstash/logstash-oss:6.3.2
+FROM jruby:9.1 AS gem-build
 
-RUN logstash-plugin install logstash-input-google_pubsub
+RUN apt-get update \
+    && apt-get install -y git \
+    && mkdir -p /usr/local/src && cd /usr/local/src/ \
+    && git clone https://github.com/SvenW/logstash-input-google_pubsub \
+    && cd logstash-input-google_pubsub \
+    && ./ci/build.sh \
+    && gem build logstash-input-google_pubsub.gemspec
+
+
+FROM docker.elastic.co/logstash/logstash-oss:6.2.4
+
+COPY --from=gem-build /usr/local/src/logstash-input-google_pubsub/logstash-input-google_pubsub-1.1.0.gem /tmp
+RUN logstash-plugin install /tmp/logstash-input-google_pubsub-1.1.0.gem
 USER root
 RUN mkdir -p /usr/share/scaife-viewer && chown logstash:logstash /usr/share/scaife-viewer
 USER logstash

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update \
     && mkdir -p /usr/local/src && cd /usr/local/src/ \
     && git clone https://github.com/SvenW/logstash-input-google_pubsub \
     && cd logstash-input-google_pubsub \
+    && git checkout f4b06da95069cd6caf8ae9ee0b6e23300649e9f6
     && ./ci/build.sh \
     && gem build logstash-input-google_pubsub.gemspec
 

--- a/logstash.conf
+++ b/logstash.conf
@@ -5,6 +5,7 @@ input {
         subscription => "search-indexer-${SCAIFE_INSTANCE}-documents-consumer"
         max_messages => 1000
         json_key_file => "/usr/share/scaife-viewer/secrets/google-key.json"
+        code => "json"
     }
 }
 output {

--- a/logstash.conf
+++ b/logstash.conf
@@ -10,6 +10,9 @@ input {
 output {
     elasticsearch {
         hosts => ["${ELASTICSEACH_HOST}"]
+        user => "${ELASTICSEARCH_USER}"
+        password => "${ELASTICSEARCH_PASSWORD}"
+        ssl => "${ELASTICSEARCH_SSL:-false}"
         action => "update"
         index => "scaife-viewer"
         document_type => "text"

--- a/logstash.conf
+++ b/logstash.conf
@@ -9,7 +9,7 @@ input {
 }
 output {
     elasticsearch {
-        hosts => ["${ELASTICSEACH_HOST}"]
+        hosts => ["${ELASTICSEARCH_HOST}"]
         user => "${ELASTICSEARCH_USER}"
         password => "${ELASTICSEARCH_PASSWORD}"
         ssl => "${ELASTICSEARCH_SSL:-false}"

--- a/logstash.conf
+++ b/logstash.conf
@@ -10,9 +10,6 @@ input {
 output {
     elasticsearch {
         hosts => ["${ELASTICSEARCH_HOST}"]
-        user => "${ELASTICSEARCH_USER}"
-        password => "${ELASTICSEARCH_PASSWORD}"
-        ssl => "${ELASTICSEARCH_SSL:-false}"
         action => "update"
         index => "${ELASTICSEARCH_INDEX_NAME:-scaife-viewer}"
         document_type => "text"

--- a/logstash.conf
+++ b/logstash.conf
@@ -14,7 +14,7 @@ output {
         password => "${ELASTICSEARCH_PASSWORD}"
         ssl => "${ELASTICSEARCH_SSL:-false}"
         action => "update"
-        index => "scaife-viewer"
+        index => "${ELASTICSEARCH_INDEX_NAME:-scaife-viewer}"
         document_type => "text"
         document_id => "%{urn}"
         doc_as_upsert => true

--- a/logstash.conf
+++ b/logstash.conf
@@ -5,7 +5,7 @@ input {
         subscription => "search-indexer-${SCAIFE_INSTANCE}-documents-consumer"
         max_messages => 1000
         json_key_file => "/usr/share/scaife-viewer/secrets/google-key.json"
-        code => "json"
+        codec => "json"
     }
 }
 output {

--- a/share/template.json
+++ b/share/template.json
@@ -45,6 +45,12 @@
           "term_vector": "with_positions_offsets",
           "store": true,
           "analyzer": "fulltext_analyzer"
+        },
+        "raw_content": {
+          "type": "text",
+          "term_vector": "with_positions_offsets",
+          "store": true,
+          "analyzer": "fulltext_analyzer"
         }
       }
     }

--- a/share/template.json
+++ b/share/template.json
@@ -1,5 +1,5 @@
 {
-  "template" : "scaife-viewer",
+  "index_patterns" : ["scaife-viewer*"],
   "mappings": {
     "text": {
       "properties": {

--- a/share/template.json
+++ b/share/template.json
@@ -12,6 +12,12 @@
         "urn": {
           "type": "keyword"
         },
+        "language": {
+          "type": "keyword"
+        },
+        "word_count": {
+          "type": "integer"
+        },
         "text_group": {
           "type": "keyword"
         },


### PR DESCRIPTION
## Features
- Updates to Logstash v6.3.2
- Adds `ELASTICSEARCH_INDEX_NAME` for customizing the index used by Logstash
- Apply template to indexes matching `scaife-viewer*`
- Add `language` and `word count` to index (allows us to run aggregate queries against ES)
- Add `raw_content` field (supports [scaife-viewer/scaife-viewer #342](https://github.com/scaife-viewer/scaife-viewer/pull/342))

## Fixes
- Fixes codec setting in PubSub input due to change to upstream pubsub plugin (db1212c8c3b645025f807e94d70d88b02ebbcd42)
- Fixes `ELASTICSEARCH_HOST` typo in config